### PR TITLE
Update saveEXT.py

### DIFF
--- a/dev/saveEXT.py
+++ b/dev/saveEXT.py
@@ -316,7 +316,8 @@ this TOX does not already exist.
 				pass
 			
 			else:
-				if eachOp.par['file'] != '':
+				# changed to check if parameter 'file' exists as well
+				if (eachOp.par['file'] != '') and (eachOp.par['file']):
 					external_dats.append(eachOp)
 				else:
 					pass


### PR DESCRIPTION
Changed find_all_dats() function to only return DATs that have a 'file' parameter. I noticed it was coloring parameter, sort, and substitute DATs as external because they do not have a 'file' parameter. I changed it to check if that parameter exists as well as that it's not an empty string before appending it to the external_dats list.

Thank you for this awesome component and your willingness to share your knowledge :)